### PR TITLE
Updating docs for CanopyTax/bandicoot#63. sanitizeHTML required. 

### DIFF
--- a/docs/components/rich-text-container.md
+++ b/docs/components/rich-text-container.md
@@ -9,12 +9,13 @@ bandicoot to work properly.
 
 ## Basic Example
 ```jsx
+import sanitizeHTML from 'sanitize-html'
 import {RichTextContainer, RichTextEditor} from 'bandicoot'
 
 function MyEditor() {
   return (
     <RichTextContainer>
-      <RichTextEditor />
+      <RichTextEditor sanitizeHTML={sanitizeHTML} />
     </RichTextContainer>
   )
 }

--- a/docs/components/rich-text-editor.md
+++ b/docs/components/rich-text-editor.md
@@ -14,12 +14,13 @@ consumed by RichTextEditor.
 
 ## Basic Example
 ```jsx
+import sanitizeHTML from 'sanitize-html'
 import {RichTextEditor, RichTextContainer} from 'bandicoot'
 
 function MyEditor() {
   return (
     <RichTextContainer>
-      <RichTextEditor />
+      <RichTextEditor sanitizeHTML={sanitizeHTML} />
     </RichTextContainer>
   )
 }
@@ -27,6 +28,7 @@ function MyEditor() {
 
 ### Advanced Example
 ```jsx
+import sanitizeHTML from 'sanitize-html'
 import {useRef} from 'react'
 import {RichTextEditor, RichTextContainer} from 'bandicoot'
 
@@ -47,7 +49,7 @@ function MyEditor() {
         save={save}
         unchangedInterval={3000}
         className="my-editor"
-        sanitizeHTML={props.myOwnSanitizationFunction}
+        sanitizeHTML={sanitizeHTML}
       />
     </RichTextContainer>
   )

--- a/docs/components/rich-text-editor.md
+++ b/docs/components/rich-text-editor.md
@@ -75,6 +75,7 @@ function MyEditor() {
 ## API
 
 ### Props
+- `sanitizeHTML` (required): A function that will be called before Bandicoot inserts a received html string into the DOM or before Bandicoot sends the DOM content out as an html string after serialization. If no function is provided, Bandicoot throws an error. See [sanitization docs](/concepts/sanitization.md) for more information.
 - `disabled` (optional): A bool that will disable the rich text editor if true
 - `initialHTML` (optional): A string of html that will be the editor's initial value. Defaults to empty string.
 - `save` (optional): A function that will be called whenever the editor blurs or no changes are made for an `unchangedInterval`.
@@ -89,7 +90,6 @@ function MyEditor() {
 - `pasteFn` (optional): A function that will be called whenever the user pastes to the editor. The function will be called with a string of text and
     returns a string that will be pasted. If you wish to prevent a paste entirely, return `false` from the pasteFn. Note that pasted HTMl is vulnerable
     to cross site scripting. See [pasting docs](/concepts/pasting.md) for more details.
-- `sanitizeHTML` (optional but **HIGHLY RECOMMENDED**): A function that will be called before Bandicoot inserts a received html string into the DOM or before Bandicoot sends the DOM content out as an html string after serialization. If no function is provided, Bandicoot will simply pass along an *unsanitized* html string. See [sanitization docs](/concepts/sanitization.md) for more information.
 
 ### Ref
 In addition to passing props, you can control the RichTextEditor imperatively with a [React ref](https://reactjs.org/docs/glossary.html#refs).

--- a/docs/concepts/sanitization.md
+++ b/docs/concepts/sanitization.md
@@ -22,7 +22,7 @@ Since Bandicoot does **NOT** automatically sanitize incoming or outgoing HTML, i
 
 If a sanitization function is provided through the `sanitizeHTML` prop, Bandicoot will pass incoming HTML strings through this function before inserting the content into the DOM (see [note 1](/concepts/sanitization.md#notes)). If provided, Bandicoot will also pass outgoing HTML through the `sanitizeHTML` function after serialization (see [note 2](/concepts/sanitization.md#notes)). If a `sanitizeHTML` function is *NOT* provided, Bandicoot will simply pass through the *unsanitized* HTML string. In the case of inserting the content into the DOM this would mean using `dangerouslySetInnerHTML` with unsanitized HTML - **NOT RECOMMENDED**!
 
-Ultimately, the choice on what sanitization process to take or what library to use is up to you. If you are looking to do client-side sanitization, there are many [third-party HTML sanitizers](https://www.npmjs.com/search?q=html+sanitizer) that already exist.
+Ultimately, the choice on what sanitization process to take or what library to use is up to you. If you are looking to do client-side sanitization, there are many [third-party HTML sanitizers](https://www.npmjs.com/search?q=html+sanitizer) that already exist. One that works well is [sanitize-html](https://github.com/apostrophecms/sanitize-html#readme).
 
 ### The `sanitizeHTML` function 
 When Bandicoot calls the `sanitizeHTML` function it passes two arguments:
@@ -40,14 +40,13 @@ Bandicoot expects your `sanitizeHTML` function to return the sanitized HTML stri
 
 ### Example
 ```js
+import sanitizeHTML from 'sanitize-html'
 import {RichTextEditor, RichTextContainer} from 'bandicoot'
 
 function MyEditor() {
   return (
     <RichTextContainer>
-      <RichTextEditor
-        sanitizeHTML={myOwnSanitizeHtmlFunction}
-      />
+      <RichTextEditor sanitizeHTML={sanitizeHTML} />
     </RichTextContainer>
   )
 }

--- a/docs/walkthrough/bold-italic-underline.md
+++ b/docs/walkthrough/bold-italic-underline.md
@@ -2,13 +2,14 @@
 
 Let's add a [control button](/concepts/control-button.md) for bolding the rich text:
 ```jsx
+import sanitizeHTML from 'sanitize-html'
 import {RichTextContainer, RichTextEditor, useDocumentExecCommand, useDocumentQueryCommandState} from 'bandicoot'
 
 function MyComponent() {
   return (
     <RichTextContainer>
       <Bold />
-      <RichTextEditor />
+      <RichTextEditor sanitizeHTML={sanitizeHTML} />
     </RichTextContainer>
   )
 }

--- a/docs/walkthrough/getting-started.md
+++ b/docs/walkthrough/getting-started.md
@@ -12,12 +12,13 @@ yarn add bandicoot
 The bandicoot library exports two components, both of which must be rendered for rich text editing.
 
 ```jsx
+import sanitizeHTML from 'sanitize-html'
 import {RichTextContainer, RichTextEditor} from 'bandicoot'
 
 function MyComponent() {
   return (
     <RichTextContainer>
-      <RichTextEditor />
+      <RichTextEditor sanitizeHTML={sanitizeHTML} />
     </RichTextContainer>
   )
 }

--- a/docs/walkthrough/headers.md
+++ b/docs/walkthrough/headers.md
@@ -4,13 +4,14 @@ NOTE: It is not recommended to attempt h1/h2/h3 tags given [the different browse
 
 Let's add a [control button](/concepts/control-button.md) for adding a block-level element around the line containing the current selection:
 ```jsx
+import sanitizeHTML from 'sanitize-html'
 import {RichTextContainer, RichTextEditor, useDocumentExecCommand, useFormatBlock} from 'bandicoot'
 
 function MyComponent() {
   return (
     <RichTextContainer>
       <HeaderButton value='h1'/>
-      <RichTextEditor />
+      <RichTextEditor sanitizeHTML={sanitizeHTML} />
     </RichTextContainer>
   )
 }


### PR DESCRIPTION
See CanopyTax/bandicoot#63. sanitizeHTML will be a required prop in 3.0.0. I'm going to wait until 3.0.0 is published before merging this.